### PR TITLE
Multiple tags

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -23,14 +23,31 @@ inputs:
 runs:
   using: "composite"
   steps: 
-    - name: Build, tag, push to AWS ECR
+    - name: Build
       id: build
-      run: |
-        docker build -t ${{ inputs.ecr-registry }}/${{ inputs.ecr-repository }}:${{ inputs.image-tag }} .
-        docker push ${{ inputs.ecr-registry }}/${{ inputs.ecr-repository }}:${{ inputs.image-tag }}
-        echo "::set-output name=image::${{ inputs.ecr-registry }}/${{ inputs.ecr-repository }}:${{ inputs.image-tag }}"
       shell: bash
+      run: docker build -t ${{ inputs.ecr-registry }}/${{ inputs.ecr-repository }} .
+
+    - name: Tag with SHA
+      id: tag-with-input
+      shell: bash
+      run: docker tag ${{ inputs.ecr-registry }}/${{ inputs.ecr-repository }} ${{ inputs.ecr-registry }}/${{ inputs.ecr-repository }}:${{ inputs.image-tag }}
+
+    - name: Tag with latest
+      id: tag-latest
+      if: github.ref == 'refs/heads/main' || github.ref == 'refs/heads/master'
+      shell: bash
+      run: docker tag ${{ inputs.ecr-registry }}/${{ inputs.ecr-repository }} ${{ inputs.ecr-registry }}/${{ inputs.ecr-repository }}:latest
+
+    - name: Push to AWS ECR
+      id: push-to-ecr
+      shell: bash
+      run: |
+        docker push ${{ inputs.ecr-registry }}/${{ inputs.ecr-repository }} --all-tags
+        echo "::set-output name=image::${{ inputs.ecr-registry }}/${{ inputs.ecr-repository }}:${{ inputs.image-tag }}"
+
     - name : Force new AWS ECS deployment
+      id: ecs-deploy
+      shell: bash
       run: |
         aws ecs update-service --cluster ${{ inputs.ecs-cluster }} --service ${{ inputs.ecs-service }} --force-new-deployment
-      shell: bash

--- a/action.yml
+++ b/action.yml
@@ -48,6 +48,7 @@ runs:
 
     - name : Force new AWS ECS deployment
       id: ecs-deploy
+      if: github.ref == 'refs/heads/main' || github.ref == 'refs/heads/master'
       shell: bash
       run: |
         aws ecs update-service --cluster ${{ inputs.ecs-cluster }} --service ${{ inputs.ecs-service }} --force-new-deployment

--- a/action.yml
+++ b/action.yml
@@ -13,7 +13,6 @@ inputs:
   image-tag:
     description: 'ECR image tag. Defaults to latest'
     required: true
-    default: 'latest'
   ecs-cluster:
     description: 'The name of the ECS cluster'
     required: true


### PR DESCRIPTION
Tag the image with multiple tags and push them all. Split the action into multiple steps for better readability.

@bnm12 I am thinking of removing the `input.image-tag` and just get the SHA from the `github` context. We are not using `image-tag` anywhere right?

That way we only have to modify this repo and we don't have to pass image-tag on every repo (meaning we can discard https://github.com/enode-engineering/enode-api/pull/36)